### PR TITLE
Trim lyric when copying to LyricOwned

### DIFF
--- a/src/lyric/mod.rs
+++ b/src/lyric/mod.rs
@@ -57,7 +57,7 @@ impl<'a> Lyric<'a> {
             Lyric::NoTimestamp => LyricOwned::NoTimestamp,
             Lyric::LineTimestamp(line) => LyricOwned::LineTimestamp(
                 line.into_iter()
-                    .map(|(text, off)| (text.to_owned(), off))
+                    .map(|(text, off)| (text.trim().to_owned(), off))
                     .collect(),
             ),
         }


### PR DESCRIPTION
Some lyrics fetched online have trailing spaces. But waylrics seems cannot handle them well:

![image](https://user-images.githubusercontent.com/2109893/235667535-a8a78fef-9575-4ccf-9707-e20c10340805.png)

This PR tries fixing this bug by trimming strings when copying from `Lyric` to `LyricOwned`.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>