### PR TITLE
Improve LRC parse handling

### DIFF
--- a/src/lyric/mod.rs
+++ b/src/lyric/mod.rs
@@ -57,7 +57,7 @@ impl<'a> Lyric<'a> {
             Lyric::NoTimestamp => LyricOwned::NoTimestamp,
             Lyric::LineTimestamp(line) => LyricOwned::LineTimestamp(
                 line.into_iter()
-                    .map(|(text, off)| (text.trim().to_owned(), off))
+                    .map(|(text, off)| (text.to_owned(), off))
                     .collect(),
             ),
         }

--- a/src/lyric/utils.rs
+++ b/src/lyric/utils.rs
@@ -2,13 +2,16 @@ use lrc_nom::{parse, LrcParseError};
 use std::time::Duration;
 
 pub fn lrc_iter<'a>(lyric: &'a str, lf: &str) -> Result<Vec<(&'a str, Duration)>, LrcParseError> {
-    Ok(parse(lyric, lf)?
+    let mut lrc_vec: Vec<_> = parse(lyric, lf)?
         .into_iter()
         .filter_map(|lrc_item| match lrc_item {
             lrc_nom::LrcItem::Metadata(_) => None,
             lrc_nom::LrcItem::Lyric(lyric, timestamp) => {
-                Some((lyric, Duration::from_millis(timestamp as u64)))
+                Some((lyric.trim(), Duration::from_millis(timestamp as u64)))
             }
         })
-        .collect())
+        .collect();
+    // handling malformed LRC timestamp by sorting them here
+    lrc_vec.sort_by(|(_, a), (_, b)| a.cmp(b));
+    Ok(lrc_vec)
 }


### PR DESCRIPTION
This modifies `lrc_iter()` in lyric/utils.rs:

- After discussing with @poly000, it shows that moving trimming logic from `Lyric` `into_owned()` to here is a better idea.
- Sort lyrics by their timestamp after collecting lyrics vector. This helps handling LRC files with timestamp in malformed order.
  - [An example](https://music.163.com/#/song?id=29771058) `[00:39.42]ずっと考えてでも\n[00:28.77]\n[00:31.19]`

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>